### PR TITLE
Fix 'Add your address' button not showing the 'Edit profile' modal

### DIFF
--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -61,7 +61,7 @@
                 <div class="user-info" *ngIf="addressExist">{{item.address}}</div>
                 <div class="user-info" *ngIf="addressExist">{{item.city}}, {{item.state}}, {{item.zip}}</div>
                 <div class="user-info">
-                    <a href="#" class="add-address" *ngIf="!addressExist" data-toggle="modal" data-target="#user-modal">Add your address</a>
+                    <button type="button" class="btn btn-link no-pad" *ngIf="!addressExist" (click)="open(content)">Add your address</button>
                 </div>
             </div>
         </div>

--- a/src/app/profile/profile.component.scss
+++ b/src/app/profile/profile.component.scss
@@ -100,13 +100,6 @@
     margin-bottom: 10px;
 }
 
-.add-address {
-    &:focus,
-    &:hover {
-        text-decoration: none !important;
-    }
-}
-
 form {
     padding: 0 30px 10px 30px;
 }


### PR DESCRIPTION
## Summary
* Fix 'Add your address' button when clicked not showing the 'Edit profile' modal and instead redirecting to home